### PR TITLE
infra: enable dev build for Roam Depot

### DIFF
--- a/dev/webpack.dev.roam.config.js
+++ b/dev/webpack.dev.roam.config.js
@@ -1,0 +1,52 @@
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const path = require("path");
+const { merge } = require("webpack-merge");
+const baseDevConfig = require("./webpack.dev.config");
+
+module.exports = merge(baseDevConfig, {
+	experiments: {
+		outputModule: true,
+	},
+	entry: path.resolve("loader.js"),
+	output: {
+		path: path.resolve("."),
+		filename: "extension.js",
+		sourceMapFilename: "extension.js.map",
+		library: {
+			type: "module",
+		}
+	},
+	plugins: [
+		new MiniCssExtractPlugin({
+			filename: "extension.css",
+		}),
+	],
+	module: {
+		rules: [
+			{
+				test: /\.(js|jsx)$/,
+				include: [path.resolve("src"), path.resolve("loader.js")],
+				use: {
+					loader: "babel-loader",
+					options: {
+						presets: ["@babel/preset-env", "@babel/preset-react"]
+					}
+				}
+			},
+			{
+				test: /\.css$/,
+				use: [
+					{
+						loader: MiniCssExtractPlugin.loader
+					},
+					{
+						loader: "css-loader",
+						options: {
+							sourceMap: false
+						}
+					}
+				],
+			},
+		],
+	}
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "build:dev": "webpack --config dev/webpack.dev.config.js",
         "build:prod": "webpack --config dev/webpack.config.js",
         "build:roam": "webpack --config dev/webpack.roam.config.js",
+		"build:dev-roam": "webpack --config dev/webpack.dev.roam.config.js",
         "build:sandbox": "webpack --config dev/webpack.sandbox.config.js",
 		"lint": "eslint loader.js sandbox.js .storybook/** src/** stories/** tests/**",
 		"lint:fix": "npm run lint -- --fix",


### PR DESCRIPTION
## Description

Adds a Webpack config and a `package.json` script to build a dev version of the `extension.js` / `extension.css` needed for Roam Depot load. The goal is to enable debugging and performance profiling for the Roam Depot version of the extension - the build command is only meant for local use.