### PR TITLE
fix: sizing and positioning of dialogs on smaller displays

### DIFF
--- a/src/components/AuxiliaryDialog/index.css
+++ b/src/components/AuxiliaryDialog/index.css
@@ -116,15 +116,15 @@
 /* SMALLER DISPLAYS */
 
 @media (max-width: 1000px){
-    .bp3-dialog[class*="zr-auxiliary-dialog--"] {
+    .bp3-dialog-container > .bp3-dialog[class*="zr-auxiliary-dialog--"] {
         --zr-dialog-gutter: 1.5%;
         --zr-dialog-margin: 5vw;
     }
 }
 
 @media (max-width: 700px){
-    .bp3-dialog[class*="zr-auxiliary-dialog--"] {
-        --zr-dialog-gutter: 1.5%;
-        --zr-dialog-margin: 2.5vw;
+    .bp3-dialog-container > .bp3-dialog[class*="zr-auxiliary-dialog--"] {
+        --zr-dialog-gutter: 1.5%!important;
+        --zr-dialog-margin: 2.5vw!important;
     }
 }

--- a/src/components/GraphWatcher/SemanticPanel/index.css
+++ b/src/components/GraphWatcher/SemanticPanel/index.css
@@ -124,7 +124,7 @@ li.import-items_selected {
 }
 
 @media (max-width: 1000px){
-    .zr-auxiliary-dialog--citations.bp3-dialog {
+    .bp3-dialog-container > .zr-auxiliary-dialog--citations.bp3-dialog {
         --zr-dialog-gutter: 1.5%;
         --zr-dialog-margin: 11vw;
     }

--- a/src/components/GraphWatcher/WebImport/index.css
+++ b/src/components/GraphWatcher/WebImport/index.css
@@ -104,7 +104,7 @@ li.zr-webimport-item {
 }
 
 @media (max-width: 1000px){
-    .zr-auxiliary-dialog--webimport.bp3-dialog {
+    .bp3-dialog-container > .zr-auxiliary-dialog--webimport.bp3-dialog {
         --zr-dialog-gutter: 1.5%;
         --zr-dialog-margin: 11vw;
     }

--- a/src/index.css
+++ b/src/index.css
@@ -52,6 +52,10 @@
     /* Required to adequately position contextual buttons */
 }
 
+#zotero-roam-portal > * {
+	z-index: 1000;
+}
+
 #zotero-roam-portal .bp3-overlay-backdrop {
     opacity: 0.4;
 }


### PR DESCRIPTION
## Description

Ensure that dialogs are displayed _over_ parts of the Roam UI (like the left sidebar), and that default media queries for auxiliary dialogs have the correct precedence (in current experience, the regular sizing of the dialogs is more specific than the general media query, meaning that dialogs don't expand on resizing unless a specific rule has been defined).

## Validation

- [ ] **Dev build**