### PR TITLE
infra(fix): only publish releases related to target branch

### DIFF
--- a/.github/workflows/dist.yaml
+++ b/.github/workflows/dist.yaml
@@ -68,11 +68,11 @@ jobs:
           echo "GitHub ref name is ${{ github.ref_name }}"
 
       - name: Publish release @beta
-        if: ${{ github.ref_name == 'beta' }}
+        if: ${{ github.ref_name == 'beta' && contains(github.event.head_commit.message, '-beta.') }}
         run: |
           npm run publish-release:beta
 
       - name: Publish release @latest
-        if: ${{ github.ref_name == 'main' }}
+        if: ${{ github.ref_name == 'main' && !contains(github.event.head_commit.message, '-beta.') }}
         run: |
           npm run publish-release:latest


### PR DESCRIPTION
## Description

Update workflow conditions for `dist.yaml` so that `chore(release)` commits only lead to publishing a release if the version matches the target branch of the `push` event.