### PR TITLE
chore: fix multiline output in CI script

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -56,8 +56,10 @@ jobs:
         id: changelog
         run: |
           changelog=$(npx auto-changelog --stdout --unreleased-only --config dev/.auto-changelog)
-          echo "changelog=$changelog" >> $GITHUB_OUTPUT
-          echo "### Changelog" >> $GITHUB_STEP_SUMMARY
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "changelog<<$EOF" >> $GITHUB_OUTPUT
+          echo "$changelog" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "$changelog" >> $GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings