### PR TITLE
chore: downgrade typescript to work with msw

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
                 "release-it": "^15.6.0",
                 "storybook-mock-date-decorator": "^1.0.0",
                 "style-loader": "^3.3.1",
-                "typescript": "^4.9.5",
+                "typescript": "^4.8.4",
                 "webpack": "^5.75.0",
                 "webpack-cli": "^5.0.1",
                 "webpack-merge": "^5.8.0"
@@ -38792,9 +38792,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+            "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -70525,9 +70525,9 @@
             }
         },
         "typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+            "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
             "dev": true
         },
         "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
         "release-it": "^15.6.0",
         "storybook-mock-date-decorator": "^1.0.0",
         "style-loader": "^3.3.1",
-        "typescript": "^4.9.5",
+        "typescript": "^4.8.4",
         "webpack": "^5.75.0",
         "webpack-cli": "^5.0.1",
         "webpack-merge": "^5.8.0"


### PR DESCRIPTION
## Description

Fix dependencies conflict with Typescript version, so that `npm update` and renovate can work again

![image](https://user-images.githubusercontent.com/29543316/227747058-416e0578-d007-4dc1-aebe-c3870408226e.png)
