### PR TITLE
tests: allow all local requests when running Chromatic

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -18,7 +18,7 @@ import { withRoamCitekeys } from "./withRoamCitekeys";
 import { withUserSettings } from "./withUserSettings";
 
 import { A11Y_RULES } from "./a11y-rules";
-import { fallbackHandler, roamAssetsHandler, sciteApiHandler, sciteAssetsHandler, apiHandlers } from "Mocks";
+import { fallbackHandler, roamAssetsHandler, sciteApiHandler, sciteAssetsHandler, apiHandlers, chromaticHandler } from "Mocks";
 
 
 // Initialize MSW
@@ -83,6 +83,7 @@ const preview: Preview = {
 				roamAssetsHandler,
 				sciteApiHandler,
 				sciteAssetsHandler,
+				chromaticHandler,
 				rest.get("http://localhost:6006/runtime*", (req, _res, _ctx) => req.passthrough()),
 				rest.get("http://localhost:6006/main*", (req, _res, _ctx) => req.passthrough()),
 				rest.get("http://localhost:6006/vendors*", (req, _res, _ctx) => req.passthrough()),

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -19,6 +19,11 @@ export const fallbackHandler = rest.get(
 	}
 );
 
+export const chromaticHandler = rest.get(
+	"https://*.chromatic.com/assets/*",
+	(req, _res, _ctx) => req.passthrough()
+);
+
 export const roamAssetsHandler = rest.get(
 	"https://roamresearch.com/assets/*", 
 	(req, _res, _ctx) => req.passthrough()


### PR DESCRIPTION
## Description

Fix an issue where navigating between Storybook components in Chromatic always throws an import error, due to a failed GET request to JS assets -- by adding a MSW passthrough handler for `https://*.chromatic.com/assets/*` requests.