### PR TITLE
chore(tests): fix flakiness in LogEntry stories

### DIFF
--- a/src/components/Logger/LogEntry/index.stories.tsx
+++ b/src/components/Logger/LogEntry/index.stories.tsx
@@ -12,9 +12,12 @@ export default {
 	component: LogEntry,
 	decorators: [
 		(Story, context) => {
+			const { args, parameters } = context;
+			const log = new ZoteroRoamLog(...parameters.logArgs);
+
 			return (
 				<ListWrapper>
-					<Story {...context} />
+					<Story {...context} args={{ ...args, log }} />
 				</ListWrapper>
 			);
 		}
@@ -23,8 +26,8 @@ export default {
 
 
 export const Error: StoryObj<Props> = {
-	args: {
-		log: new ZoteroRoamLog(
+	parameters: {
+		logArgs: [
 			{
 				origin: "API",
 				message: "Failed to fetch",
@@ -37,13 +40,13 @@ export const Error: StoryObj<Props> = {
 				}
 			},
 			"error"
-		)
+		]
 	}
 };
 
 export const Warning: StoryObj<Props> = {
-	args: {
-		log: new ZoteroRoamLog(
+	parameters: {
+		logArgs: [
 			{
 				origin: "Shortcuts",
 				message: "Hotkey combo is not valid",
@@ -52,19 +55,19 @@ export const Warning: StoryObj<Props> = {
 				}
 			},
 			"warning"
-		)
+		]
 	}
 };
 
 export const Info: StoryObj<Props> = {
-	args: {
-		log: new ZoteroRoamLog(
+	parameters: {
+		logArgs: [
 			{
 				origin: "Setup",
 				message: "Extension initialized from roam/js",
 				context: {}
 			},
 			"info"
-		)
+		]
 	}
 };


### PR DESCRIPTION
### Description

Fix a longstanding issue with the `LogEntry` stories, where the current date isn't mocked in CI (even though it's mocked when running Storybook locally) -- by moving the log creation step in the decorator, instead of the story args.