### PR TITLE
chore: update Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,7 +19,7 @@
 	},
 	{
 		"matchUpdateTypes": ["major"],
-		"matchPackageNames": [
+		"matchDepNames": [
 			"@blueprintjs/core",
 			"@blueprintjs/datetime",
 			"@blueprintjs/select",
@@ -30,14 +30,14 @@
 		"enabled": false
 	},
 	{
-		"matchPackageNames": [
+		"matchDepNames": [
 			"scite-badge"
 		],
 		"enabled": false
 	},
 	{
 		"groupName": "Storybook Core",
-		"matchPackageNames": [
+		"matchDepNames": [
 			"@storybook/addon-a11y",
 			"@storybook/addon-actions",
 			"@storybook/addon-controls",


### PR DESCRIPTION
## Description

`matchPackageNames` should no longer be used, it should be `matchDepNames`  instead.