### PR TITLE
chore: remove imports from Storybook addons

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,5 +1,5 @@
 /* istanbul ignore file */
-import { useEffect, useGlobals } from "@storybook/addons";
+import { useEffect } from "react";
 import { Decorator, Preview, StoryContext, StoryFn } from "@storybook/react";
 import { initialize, mswLoader } from "msw-storybook-addon";
 import { http, passthrough } from "msw";
@@ -30,7 +30,7 @@ initialize({
 
 // https://storybook.js.org/docs/react/essentials/toolbars-and-globals
 const withTheme: Decorator = (Story: StoryFn, context: StoryContext) => {
-	const [{ theme }/*, updateGlobals */] = useGlobals();
+	const { theme } = context.globals;
 
 	useEffect(() => {
 		document.getElementById("storybook-root")?.parentElement?.setAttribute("zr-dark-theme", (theme == "dark").toString());


### PR DESCRIPTION
## Description

Running the Storybook locally doesn't work even on a fresh install, with an issue coming from deep within the `@storybook/addons` package. I tried switching to the `@storybook/manager-api` import instead, which is what the official docs currently suggest when writing addons - but in my context it didn't work (useStorybookAPI isn't able to provide an object). I looked up the decorator docs instead and they suggest getting globals from the context.

(Not sure why it has been working fine in CI/Chromatic)

## Validation

✅  Stories load successfully locally